### PR TITLE
feat: add "prepare nodejs" composite actions

### DIFF
--- a/.github/actions/prepare-nodejs/action.yml
+++ b/.github/actions/prepare-nodejs/action.yml
@@ -1,0 +1,21 @@
+name: Prepare Node.js
+
+description: Common steps for preparing Node.js environment
+
+inputs:
+  node-version:
+    description: The version of Node.js to use
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+
+    - name: Install dependencies
+      run: |
+        yarn install
+      shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-
-      - run: yarn install
+      - uses: ./.github/actions/prepare-node
+        with:
+          node-version: 20
 
       - run: yarn lint
 
@@ -31,9 +31,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-
-      - run: yarn install
+      - uses: ./.github/actions/prepare-node
+        with:
+          node-version: 20
 
       - run: yarn test
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # cause this composite actions haven't been merged into default branch, so you'll have to use a `ref` pointer to find it,
-      # otherwise, it shall look like this.
-      # - uses: ./.github/actions/prepare-node
-      - uses: ./.github/actions/prepare-node@feat/add-composite-actions-prepare-nodejs
+      - uses: ./.github/actions/prepare-node
         with:
           node-version: 20
 
@@ -34,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/prepare-node@feat/add-composite-actions-prepare-nodejs
+      - uses: ./.github/actions/prepare-node
         with:
           node-version: 20
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/prepare-node
+      # cause this composite actions haven't been merged into default branch, so you'll have to use a `ref` pointer to find it,
+      # otherwise, it shall look like this.
+      # - uses: ./.github/actions/prepare-node
+      - uses: ./.github/actions/prepare-node@feat/add-composite-actions-prepare-nodejs
         with:
           node-version: 20
 
@@ -31,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/prepare-node
+      - uses: ./.github/actions/prepare-node@feat/add-composite-actions-prepare-nodejs
         with:
           node-version: 20
 


### PR DESCRIPTION
Use [Composite Action](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action) to extract reusable steps into `.github/actions/...`, then you can call the composite actions over all of your GitHub workflows.

Pros:
* Easy to setup
* Flexible to be used across files
* You can call another composite action in one composite action, which means nested calling is possible. But it's up to 10 layers.

Cons:
* Not able to use `secrets: inherit`, you have to send your `secrets` into the `inputs` fields of composite actions.
* It's hard to treat it as a normal task; you'll have to pass all possible variables to the composite actions.